### PR TITLE
Open Legend: Actions draggable to Macro Quick Bar

### DIFF
--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -2641,7 +2641,7 @@ var TAS = TAS || (function(){
             <div class="evasion vertTop padTop">
                 <div class="inlineBlock vertTop padTop" style="width: 155px;">
                     <div class="column width100 textCenter resistButton">
-                        <button type="roll" value="&{template:openLegend} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Evasion</button>
+                        <button type="roll" name="roll_resist_bane" value="&{template:openLegend} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Evasion</button>
                     </div>
                     <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_evasion" value=0 /></div>
                 </div>
@@ -2666,7 +2666,7 @@ var TAS = TAS || (function(){
             <div class="toughness vertTop padTop">
                 <div class="inlineBlock vertTop padTop" style="width: 155px;">
                     <div class="column width100 textCenter resistButton">
-                        <button type="roll" value="&{template:openLegend} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Toughness</button>
+                        <button type="roll" name="roll_resist_bane" value="&{template:openLegend} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Toughness</button>
                     </div>
                     <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_toughness" value=0 /></div>
                 </div>
@@ -2688,7 +2688,7 @@ var TAS = TAS || (function(){
             <div class="resolve vertTop padTop">
                 <div class="inlineBlock vertTop padTop" style="width: 155px;">
                     <div class="column width100 textCenter resistButton">
-                        <button type="roll" value="&{template:openLegend} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Resolve</button>
+                        <button type="roll" name="roll_resist_bane" value="&{template:openLegend} {{title= Resist Bane Roll}} {{subTitle= @{character_name}}} {{roll= [[1d20]]}} {{target= 10+ bane is removed}}">Resolve</button>
                     </div>
                     <div class="column width100 inputNumberLarge padTop"><input type="number" name="attr_resolve" value=0 /></div>
                 </div>
@@ -2718,7 +2718,7 @@ var TAS = TAS || (function(){
                 <fieldset class="repeating_actions">
                     <div class="row">   <!-- Fix for Mozilla squishing +Add & Modify buttons -->
                         <div class="width15 inlineBlock vertTop padLeft"><input class="settings" type="checkbox" name="attr_settingsFlag" value="on" checked="checked" /><span>y</span></div>
-                        <div class="width85 inlineBlock vertTop inputNameShort attributeButton teal"><button type="roll" value="&{template:openLegend} {{title= @{action_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= @{action_attribute}}} {{target= @{action_target}}} {{roll= @{dice_roll}}} {{description= @{action_special}}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
+                        <div class="width85 inlineBlock vertTop inputNameShort attributeButton teal"><button type="roll" name="roll_action" value="&{template:openLegend} {{title= @{action_name}}} {{subTitle= @{character_name}}} {{subTitleAdd= @{action_attribute}}} {{target= @{action_target}}} {{roll= @{dice_roll}}} {{description= @{action_special}}}"><input type="text" style="text-align: center;" name="attr_action_name" /></button></div>
                         <input type="hidden" class="displaySettingsFlag" name="attr_displaySettingsFlag" />
                         <div class="width100 displaySettings padLeft">
                             <div class="column width25 inlineBlock bold">Name: </div>
@@ -2805,7 +2805,7 @@ var TAS = TAS || (function(){
         <div class="speedLethalDamage padTop">
             <div class="width50 inlineBlock vertTop">
                 <input type="hidden" name="attr_agility_initiative" value=0 />
-                <div class="column width100 textCenter textLarge speedButton"><button type="roll" value="&{template:openLegend} {{title= Initiative Roll}} {{subTitle= @{character_name}}} {{subTitleAdd= Agility}} {{roll= @{agility_initiative}}} {{description= Make sure to you selected your token to have it automatically added to the turn order.}}">Speed</button></div>
+                <div class="column width100 textCenter textLarge speedButton"><button type="roll" name="roll_initiative" value="&{template:openLegend} {{title= Initiative Roll}} {{subTitle= @{character_name}}} {{subTitleAdd= Agility}} {{roll= @{agility_initiative}}} {{description= Make sure to you selected your token to have it automatically added to the turn order.}}">Speed</button></div>
                 <div class="column width100 vertTop inputNumber30 textSmall bold">Base <input type="number" name="attr_base_speed" value=30 /></div>
                 <div class="column width100 inputNumberLarge"><input type="number" name="attr_speed" value=0 /></div>
                 <div class="width100 column inputNumber30 textSmall bold">Armor Penalty(ft) <input type="number" name="attr_armor_penalty" value=0 /></div>

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -5,6 +5,13 @@
 
 ### Changelog
 
+### 1.6.1 on 2016 November 29th
+* Added the ability to add roll buttons to macro quick bar
+	- Actions can be dragged to the marcro quick bar
+	- "Speed" aka Initiative can be dragged to macro quick bar
+	- "Evasion", "Toughness", and/or "Resolve" aka Resist Bane can be dragged to macro quick bar (all are the same as each other)
+	- Currently Attributes, Feats, Flaws, and Perks can NOT be added to the macro quick bar (nor are plans to implement at this time)
+
 ### 1.6.0 on 2016 November 28th
 * Added graphics for the roll/chat window
 	- Updated buttons for rolling to use the new template "openLegend"
@@ -106,26 +113,26 @@
 
 ## Plans
 * Fix Top info section of sheet to compress when page is shrunk
-* Make Action rolls calculate their own string for Rolls
-	+Have a spot for advantage/disadvantage that is permanent to that action roll
-* Make a settings section for each Attribute
-	+ For the physical: drop down menu for attribute subsitution
-	+ For might, checkbox on whether attribute subsitution affects heavy carry
-	+ For all, an option to increase or decrease dice size above/below what the attribute score would normally allow
-	+ Option to Keep Highest/Lowest of d20 (based on certain feats)
-[done 2016 Nov 19] * Have fields for adjusting the Hit Point total for feats and other
+* [done] Make Action rolls calculate their own string for Rolls
+	+[no longer planned due to complexity of roll string] Have a spot for advantage/disadvantage that is permanent to that action roll
+* [done] Make a settings section for each Attribute
+	+ [done] For the physical: drop down menu for attribute subsitution
+	+ [done] For might, checkbox on whether attribute subsitution affects heavy carry
+	+ [done] For all, an option to increase or decrease dice size above/below what the attribute score would normally allow
+	+ [done] Option to Keep Highest/Lowest of d20 (based on certain feats)
+* [done 2016 Nov 19] Have fields for adjusting the Hit Point total for feats and other
 	[done 2016 Nov 19] + Have "Fortitude, Presence, & Will" listed below Hit Points so people know which attributes affect Hit Points
-[done]* Make Inventory Section
-[done]* Include more fields for Feats, Perks, & Flaws
-	[done]+ Plus ability to click to roll them so all can see info about
-[done]* Include Inventory into speed (how it affects)
-[done]* Creation of a "fancy (advanced)" version of the sheet
-	+ More optimization for web (and potentially mobile)
-	+ Sections that disappear with a click
+* [done] Make Inventory Section
+* [done] Include more fields for Feats, Perks, & Flaws
+	+[done] Plus ability to click to roll them so all can see info about
+* [done] Include Inventory into speed (how it affects)
+* [done] Creation of a "fancy (advanced)" version of the sheet
+	+ [done] More optimization for web (and potentially mobile)
+	+ [done] Sections that disappear with a click
 * A settings section where you could modify certain values
 	+ For "homebrew" and if changes come up before final release of product
-* A rolltemplete that isn't using the default
-	+ Adding in a pop-up for target CR to caculate and do the math if you hit & damage
+* [done] A rolltemplete that isn't using the default
+	+ [in progress] Adding in a pop-up for target CR to caculate and do the math if you hit & damage
 * Clean up the CSS code
 	- Currently includes a lot from a previous sheet I was using, some code doesn't apply
 


### PR DESCRIPTION
### 1.6.1 on 2016 November 29th
* Added the ability to add roll buttons to macro quick bar
- Actions can be dragged to the marcro quick bar
- "Speed" aka Initiative can be dragged to macro quick bar
- "Evasion", "Toughness", and/or "Resolve" aka Resist Bane can be
dragged to macro quick bar (all are the same as each other)
- Currently Attributes, Feats, Flaws, and Perks can NOT be added to the
macro quick bar (nor are plans to implement at this time)