### PR TITLE
Supernatural to Extraordinary & Dice Size Change option for Actions

### DIFF
--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -1357,7 +1357,7 @@ repeating_items
         getSectionIDs("repeating_actions", function(actionsArray) {
          if(actionsArray.length > 0) {
             _.each(actionsArray, function(currentID, i) {
-                getAttrs(["repeating_actions_" + currentID + "_action_attribute", "repeating_actions_" + currentID + "_dice_d20", "repeating_actions_" + currentID + "_use_power_level", "repeating_actions_" + currentID + "_power_level", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
+                getAttrs(["repeating_actions_" + currentID + "_action_attribute", "repeating_actions_" + currentID + "_dice_d20", "repeating_actions_" + currentID + "_dice_modifier", "repeating_actions_" + currentID + "_use_power_level", "repeating_actions_" + currentID + "_power_level", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
                     var update = {};
                     var score = 0;
                     if(v["repeating_actions_" + currentID + "_action_attribute"] === "Agility") {
@@ -1397,6 +1397,7 @@ repeating_items
                     } else if(v["repeating_actions_" + currentID + "_action_attribute"] === "Protection") {
                         score = v.protection_score*1 + v.protection_dice_modifier*1;
                     }
+                    score = score*1 + v["repeating_actions_" + currentID + "_dice_modifier"]*1;
                     var number = calcAttributeDiceNumber(score);
                     var type = calcAttributeDiceType(score);
                     var roll = "";
@@ -1426,7 +1427,7 @@ repeating_items
         getSectionIDs("repeating_otheractions", function(actionsArray) {
          if(actionsArray.length > 0) {
             _.each(actionsArray, function(currentID, i) {
-                getAttrs(["repeating_otheractions_" + currentID + "_action_attribute", "repeating_otheractions_" + currentID + "_dice_d20", "repeating_otheractions_" + currentID + "_use_power_level", "repeating_otheractions_" + currentID + "_power_level", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
+                getAttrs(["repeating_otheractions_" + currentID + "_action_attribute", "repeating_otheractions_" + currentID + "_dice_d20", "repeating_otheractions_" + currentID + "_dice_modifier", "repeating_otheractions_" + currentID + "_use_power_level", "repeating_otheractions_" + currentID + "_power_level", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(v) {
                     var updateother = {};
                     var score = 0;
                     if(v["repeating_otheractions_" + currentID + "_action_attribute"] === "Agility") {
@@ -1466,6 +1467,7 @@ repeating_items
                     } else if(v["repeating_otheractions_" + currentID + "_action_attribute"] === "Protection") {
                         score = v.protection_score*1 + v.protection_dice_modifier*1;
                     }
+                    score = score*1 + v["repeating_otheractions_" + currentID + "_dice_modifier"]*1;
                     var number = calcAttributeDiceNumber(score);
                     var type = calcAttributeDiceType(score);
                     var roll = "";
@@ -1522,8 +1524,8 @@ repeating_items
         });
     });
 	// On Change for calculating rolls for Actions
-    on("change:repeating_actions:action_attribute change:repeating_actions:dice_d20", function() {
-        getAttrs(["repeating_actions_action_attribute", "repeating_actions_dice_d20", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
+    on("change:repeating_actions:action_attribute change:repeating_actions:dice_d20 change:repeating_actions:dice_modifier", function() {
+        getAttrs(["repeating_actions_action_attribute", "repeating_actions_dice_d20", "repeating_actions_dice_modifier", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
             var score = 0;
             if(values.repeating_actions_action_attribute === "Agility") {
                 score = values.agility_score*1 + values.agility_dice_modifier*1;
@@ -1562,6 +1564,7 @@ repeating_items
             } else if(values.repeating_actions_action_attribute === "Protection") {
                 score = values.protection_score*1 + values.protection_dice_modifier*1;
             }
+            score = score*1 + values.repeating_actions_dice_modifier*1;
             var number = calcAttributeDiceNumber(score);
             var type = calcAttributeDiceType(score);
 			var roll = "";
@@ -1576,8 +1579,8 @@ repeating_items
         });
     });
 	// On Change for calculating rolls for Actions
-    on("change:repeating_otheractions:action_attribute change:repeating_otheractions:dice_d20", function() {
-        getAttrs(["repeating_otheractions_action_attribute", "repeating_otheractions_dice_d20", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
+    on("change:repeating_otheractions:action_attribute change:repeating_otheractions:dice_d20 change:repeating_otheractions:dice_modifier", function() {
+        getAttrs(["repeating_otheractions_action_attribute", "repeating_otheractions_dice_d20", "repeating_otheractions_dice_modifier", "agility_score", "agility_dice_modifier", "fortitude_score", "fortitude_dice_modifier", "might_score", "might_dice_modifier", "learning_score", "learning_dice_modifier", "logic_score", "logic_dice_modifier", "perception_score", "perception_dice_modifier", "will_score", "will_dice_modifier", "deception_score", "deception_dice_modifier", "persuasion_score", "persuasion_dice_modifier", "presence_score", "presence_dice_modifier", "alteration_score", "alteration_dice_modifier", "creation_score", "creation_dice_modifier", "energy_score", "energy_dice_modifier", "entropy_score", "entropy_dice_modifier", "influence_score", "influence_dice_modifier", "movement_score", "movement_dice_modifier", "prescience_score", "prescience_dice_modifier", "protection_score", "protection_dice_modifier"], function(values) {
             var score = 0;
             if(values.repeating_otheractions_action_attribute === "Agility") {
                 score = values.agility_score*1 + values.agility_dice_modifier*1;
@@ -1616,6 +1619,7 @@ repeating_items
             } else if(values.repeating_otheractions_action_attribute === "Protection") {
                 score = values.protection_score*1 + values.protection_dice_modifier*1;
             }
+            score = score*1 + values.repeating_otheractions_dice_modifier*1;
             var number = calcAttributeDiceNumber(score);
             var type = calcAttributeDiceType(score);
 			var roll = "";
@@ -2289,7 +2293,7 @@ var TAS = TAS || (function(){
 <!-- Main body of Character Sheet -->
 <div class="container">     <!-- defines the width/height & behavior of the page -->
     <div class="row width100 padBottom">
-        <div class="column textSmall textRight padRight">2016.12.23 <span class="bold">Version 1.7.2 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
+        <div class="column textSmall textRight padRight">2016.12.23 <span class="bold">Version 1.7.3 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
     </div>
     <div class="row width100">
         <div class="column width10 inlineBlock textSmall bold">Character Info</div>
@@ -3212,6 +3216,8 @@ var TAS = TAS || (function(){
                                 </select>
                             </div>
                             <input type="hidden" name="attr_dice_roll" value=0 />
+                            <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                            <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
                             <div class="column width55 inlineBlock">d20 for this action is:</div>
                             <input type="hidden" name="attr_dice_d20" value="1d20!!" />
                             <div class="column width45 inlineBlock inputSelect">
@@ -3296,6 +3302,8 @@ var TAS = TAS || (function(){
                                 </select>
                             </div>
                             <input type="hidden" name="attr_dice_roll" value=0 />
+                            <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                            <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
                             <div class="column width55 inlineBlock">d20 for this action is:</div>
                             <input type="hidden" name="attr_dice_d20" value="1d20!!" />
                             <div class="column width45 inlineBlock inputSelect">

--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -2289,7 +2289,7 @@ var TAS = TAS || (function(){
 <!-- Main body of Character Sheet -->
 <div class="container">     <!-- defines the width/height & behavior of the page -->
     <div class="row width100 padBottom">
-        <div class="column textSmall textRight padRight">2016.12.15 <span class="bold">Version 1.7.1 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
+        <div class="column textSmall textRight padRight">2016.12.23 <span class="bold">Version 1.7.2 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
     </div>
     <div class="row width100">
         <div class="column width10 inlineBlock textSmall bold">Character Info</div>
@@ -2780,8 +2780,8 @@ var TAS = TAS || (function(){
             </div>
         </div>
     <!-- end mental attributes -->
-    <!-- Supernatural Attributes -->
-        <div class="column width100 textLeft bold textLarger gray">SUPERNATURAL</div>
+    <!-- Extraordinary Attributes -->
+        <div class="column width100 textLeft bold textLarger gray">EXTRAORDINARY</div>
       <!-- Header Area -->
         <div class="row width100">
             <div class="column width45 inlineBlock textSmall textLeft bold italic">Click name to Roll</div>
@@ -3023,7 +3023,7 @@ var TAS = TAS || (function(){
                 </div>
             </div>
         </div>
-    <!-- end of supernatural attributes -->
+    <!-- end of EXTRAORDINARY attributes -->
     </div>
  <!-- end of left column for Attributes -->
 <div class="twoThird inlineBlock">

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -8,6 +8,7 @@
 ### 1.7.1 on 2016 December 15th
 * Modified power level to have a min and max value to input
 	- Success message in chat output based on min value, but tells you for both.
+* Mozilla Firefox UI issues should now be resolved.
 
 ### 1.7.0 on 2016 December 13th
 * Added another actions section

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -5,6 +5,10 @@
 
 ### Changelog
 
+### 1.7.3 on 2016 December 23rd
+* Added an option under "Favored Actions" and "Other Actions" to allow modification of dice size for rolling
+	- This is mainly for the "Martial Focus" feat, or anyothers that may come along (maybe even items).
+
 ### 1.7.2 ON 2016 December 23rd
 * Changed refrences from Supernatural to Extraordinary where applicable
 

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -5,6 +5,9 @@
 
 ### Changelog
 
+### 1.7.2 ON 2016 December 23rd
+* Changed refrences from Supernatural to Extraordinary where applicable
+
 ### 1.7.1 on 2016 December 15th
 * Modified power level to have a min and max value to input
 	- Success message in chat output based on min value, but tells you for both.


### PR DESCRIPTION
### 1.7.3 on 2016 December 23rd
* Added an option under "Favored Actions" and "Other Actions" to allow modification of dice size for rolling
	- This is mainly for the "Martial Focus" feat, or anyothers that may come along (maybe even items).

### 1.7.2 ON 2016 December 23rd
* Changed refrences from Supernatural to Extraordinary where applicable

 ### 1.7.1 on 2016 December 15th
 * Modified power level to have a min and max value to input
 	- Success message in chat output based on min value, but tells you for both.
* Mozilla Firefox UI issues should now be resolved.