### PR TITLE
Open Legend: Attribute Sub & Guard

### DIFF
--- a/Open Legend Basic by Great Moustache/Open Legend.css
+++ b/Open Legend Basic by Great Moustache/Open Legend.css
@@ -621,7 +621,22 @@ input.sheet-checkboxSliderInvis {
 /* Hide and Show different sections */
 .sheet-agility_display_sub_flag[value="show"] ~ .sheet-sub,
 .sheet-fortitude_display_sub_flag[value="show"] ~ .sheet-sub,
-.sheet-might_display_sub_flag[value="show"] ~ .sheet-sub {
+.sheet-might_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-learning_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-logic_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-perception_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-will_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-deception_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-persuasion_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-presence_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-alteration_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-creation_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-energy_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-entropy_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-influence_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-movement_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-prescience_display_sub_flag[value="show"] ~ .sheet-sub,
+.sheet-protection_display_sub_flag[value="show"] ~ .sheet-sub {
     background-color: #7FDBFF;
 }
 

--- a/Open Legend Basic by Great Moustache/Open Legend.html
+++ b/Open Legend Basic by Great Moustache/Open Legend.html
@@ -1,106 +1,3 @@
-<!-- List of all attributes "attr_*"
-attr_character_name		attr_player_name	attr_archetype		attr_level		attr_xp		attr_description
-attr_attribute_points	attr_attribute_points_spent
-attr_agility_score		attr_show_agility_cost      attr_agility_cost		attr_agility_dice_roll		    attr_agility_dice
-        attr_agility_display_settings_flag          attr_agility_settings_flag
-        attr_agility_dice_d20                       attr_agility_cost_modifier                              attr_agility_dice_modifier
-attr_fortitude_score	attr_show_fortitude_cost    attr_fortitude_cost		attr_fortitude_dice_roll		attr_fortitude_dice
-        attr_fortitude_display_settings_flag        attr_fortitude_settings_flag
-        attr_fortitude_dice_d20                     attr_fortitude_cost_modifier                            attr_fortitude_dice_modifier
-attr_might_score		attr_show_might_cost        attr_might_cost			attr_might_dice_roll			attr_might_dice
-        attr_might_display_settings_flag            attr_might_settings_flag
-        attr_might_dice_d20                         attr_might_cost_modifier                                attr_might_dice_modifier
-attr_deception_score	attr_show_deception_cost    attr_deception_cost		attr_deception_dice_roll		attr_deception_dice
-        attr_deception_display_settings_flag        attr_deception_settings_flag
-        attr_deception_dice_d20                     attr_deception_cost_modifier                            attr_deception_dice_modifier
-attr_presence_score		attr_show_presence_cost     attr_presence_cost		attr_presence_dice_roll		    attr_presence_dice
-        attr_presence_display_settings_flag         attr_presence_settings_flag
-        attr_presence_dice_d20                      attr_presence_cost_modifier                             attr_presence_dice_modifier
-attr_persuasion_score	attr_show_persuasion_cost   attr_persuasion_cost	attr_persuasion_dice_roll		attr_persuasion_dice
-        attr_persuasion_display_settings_flag       attr_persuasion_settings_flag
-        attr_persuasion_dice_d20                    attr_persuasion_cost_modifier                           attr_persuasion_dice_modifier
-attr_learning_score		attr_show_learning_cost     attr_learning_cost		attr_learning_dice_roll		    attr_learning_dice
-        attr_learning_display_settings_flag         attr_learning_settings_flag
-        attr_learning_dice_d20                      attr_learning_cost_modifier                             attr_learning_dice_modifier
-attr_logic_score		attr_show_logic_cost        attr_logic_cost			attr_logic_dice_roll			attr_logic_dice
-        attr_logic_display_settings_flag            attr_logic_settings_flag
-        attr_logic_dice_d20                         attr_logic_cost_modifier                                attr_logic_dice_modifier
-attr_perception_score	attr_show_perception_cost   attr_perception_cost	attr_perception_dice_roll		attr_perception_dice
-        attr_perception_display_settings_flag       attr_perception_settings_flag
-        attr_perception_dice_d20                    attr_perception_cost_modifier                           attr_perception_dice_modifier
-attr_will_score			attr_show_will_cost         attr_will_cost			attr_will_dice_roll			    attr_will_dice
-        attr_will_display_settings_flag             attr_will_settings_flag
-        attr_will_dice_d20                          attr_will_cost_modifier                                 attr_will_dice_modifier
-attr_alteration_score	attr_show_alteration_cost   attr_alteration_cost	attr_alteration_dice_roll		attr_alteration_dice
-        attr_alteration_display_settings_flag       attr_alteration_settings_flag
-        attr_alteration_dice_d20                    attr_alteration_cost_modifier                           attr_alteration_dice_modifier
-attr_creation_score		attr_show_creation_cost     attr_creation_cost		attr_creation_dice_roll		    attr_creation_dice
-        attr_creation_display_settings_flag         attr_creation_settings_flag
-        attr_creation_dice_d20                      attr_creation_cost_modifier                             attr_creation_dice_modifier
-attr_energy_score		attr_show_energy_cost       attr_energy_cost		attr_energy_dice_roll			attr_energy_dice
-        attr_energy_display_settings_flag           attr_energy_settings_flag
-        attr_energy_dice_d20                        attr_energy_cost_modifier                               attr_energy_dice_modifier
-attr_entropy_score		attr_show_entropy_cost      attr_entropy_cost		attr_entropy_dice_roll		    attr_entropy_dice
-        attr_entropy_display_settings_flag          attr_entropy_settings_flag
-        attr_entropy_dice_d20                       attr_entropy_cost_modifier                              attr_entropy_dice_modifier
-attr_influence_score	attr_show_influence_cost    attr_influence_cost		attr_influence_dice_roll		attr_influence_dice
-        attr_influence_display_settings_flag        attr_influence_settings_flag
-        attr_influence_dice_d20                     attr_influence_cost_modifier                            attr_influence_dice_modifier
-attr_movement_score		attr_show_movement_cost     attr_movement_cost		attr_movement_dice_roll		    attr_movement_dice
-        attr_movement_display_settings_flag         attr_movement_settings_flag
-        attr_movement_dice_d20                      attr_movement_cost_modifier                             attr_movement_dice_modifier
-attr_prescience_score	attr_show_prescience_cost   attr_prescience_cost	attr_prescience_dice_roll		attr_prescience_dice
-        attr_prescience_display_settings_flag       attr_prescience_settings_flag
-        attr_prescience_dice_d20                    attr_prescience_cost_modifier                           attr_prescience_dice_modifier
-attr_protection_score	attr_show_protection_cost   attr_protection_cost	attr_protection_dice_roll		attr_protection_dice
-        attr_protection_display_settings_flag       attr_protection_settings_flag
-        attr_protection_dice_d20                    attr_protection_cost_modifier                           attr_protection_dice_modifier
-attr_armor		    attr_show_armor             attr_show_shield        attr_shield
-attr_armor_penalty  attr_armor_training
-attr_evasion	    attr_show_agility_score		attr_evasion_other
-attr_toughness	    attr_show_fortitude_score	attr_toughness_other
-attr_resolve	    attr_show_presence_score	attr_show_will_score	attr_resolve_other
-attr_hit_point	    attr_hit_point_max          attr_hit_point_feats    attr_hit_point_other
-attr_lethal_damage
-attr_legend_points		attr_base_speed         attr_speed
-attr_wealth_level
-repeating_actions
-	attr_action_name
-	attr_action_show_name
-	attr_action_attribute
-	attr_action_target
-	attr_action_special
-	attr_action_settings
-	attr_power_target
-	attr_use_power_level
-	attr_power_level
-attr_feat_total_points		attr_feat_points_spent
-repeating_featsLeft
-	attr_feat_left_name         attr_feat_left_show_name        attr_feat_left_cost
-	attr_feat_left_settings     attr_feat_left_description
-repeating_featsRight
-	attr_feat_right_name        attr_feat_right_show_name       attr_feat_right_cost
-	attr_feat_right_settings    attr_feat_right_description
-repeating_perks
-	attr_perk_name          attr_perk_show_name
-	attr_perk_settings      attr_perk_description
-repeating_flaws
-	attr_flaw_name          attr_flaw_show_name
-	attr_flaw_settings      attr_flaw_description
-attr_item_heavy     attr_item_heavy_result  attr_item_bulky         attr_item_bulky_result
-attr_item_1         attr_item_1_heavy       attr_item_1_bulky       attr_item_2         attr_item_2_heavy       attr_item_2_bulky
-attr_item_3         attr_item_3_heavy       attr_item_3_bulky       attr_item_4         attr_item_4_heavy       attr_item_4_bulky
-attr_item_5         attr_item_5_heavy       attr_item_5_bulky       attr_item_6         attr_item_6_heavy       attr_item_6_bulky
-attr_item_7         attr_item_7_heavy       attr_item_7_bulky       attr_item_8         attr_item_8_heavy       attr_item_8_bulky
-attr_item_9         attr_item_9_heavy       attr_item_9_bulky       attr_item_10        attr_item_10_heavy      attr_item_10_bulky
-attr_item_11        attr_item_11_heavy      attr_item_11_bulky      attr_item_12        attr_item_12_heavy      attr_item_12_bulky
-attr_item_13        attr_item_13_heavy      attr_item_13_bulky      attr_item_14        attr_item_14_heavy      attr_item_14_bulky
-attr_item_15        attr_item_15_heavy      attr_item_15_bulky      attr_item_16        attr_item_16_heavy      attr_item_16_bulky
-attr_item_17        attr_item_17_heavy      attr_item_17_bulky      attr_item_18        attr_item_18_heavy      attr_item_18_bulky
-attr_item_19        attr_item_19_heavy      attr_item_19_bulky      attr_item_20        attr_item_20_heavy      attr_item_20_bulky
-repeating_items
-    attr_item_name          attr_item_contents
--->
 <!-- Worker Scripts -->
 <script type="text/worker">
 	// The first time the sheet is opened, run all functions that calculate fields in case of any changes or updates
@@ -168,6 +65,228 @@ repeating_items
         calcEvasion();
         calcToughness();
     });
+	
+	// Function for determining Substitution Values
+	function calcSubstitutionScore(subPrimary, subSecondary) {
+        getAttrs(["might_score", "agility_score", "fortitude_score", "learning_score", "logic_score", "perception_score", "will_score", "deception_score", "persuasion_score", "presence_score", "alteration_score", "creation_score", "energy_score", "entropy_score", "influence_score", "movement_score", "prescience_score", "protection_score"], function(values) {
+			var score = -1;
+			var sub = "show";
+			switch(subPrimary) {
+				case 'Agility':
+					score = values.agility_score*1;
+					break;
+				case 'Fortitude':
+					score = values.fortitude_score*1;
+					break;
+				case 'Might':
+					score = values.might_score*1;
+					break;
+				case 'Learning':
+					score = values.learning_score*1;
+					break;
+				case 'Logic':
+					score = values.logic_score*1;
+					break;
+				case 'Perception':
+					score = values.perception_score*1;
+					break;
+				case 'Will':
+					score = values.will_score*1;
+					break;
+				case 'Deception':
+					score = values.deception_score*1;
+					break;
+				case 'Persuasion':
+					score = values.persuasion_score*1;
+					break;
+				case 'Presence':
+					score = values.presence_score*1;
+					break;
+				case 'Alteration':
+					score = values.alteration_score*1;
+					break;
+				case 'Creation':
+					score = values.creation_score*1;
+					break;
+				case 'Energy':
+					score = values.energy_score*1;
+					break;
+				case 'Entropy':
+					score = values.entropy_score*1;
+					break;
+				case 'Influence':
+					score = values.influence_score*1;
+					break;
+				case 'Movement':
+					score = values.movement_score*1;
+					break;
+				case 'Prescience':
+					score = values.prescience_score*1;
+					break;
+				case 'Protection':
+					score = values.protection_score*1;
+					break;
+				case 'None':
+					score = -1;
+					break;
+				default:
+					score = -1;
+					break;
+			}
+			if(score < 0) {
+				score = 0;
+				sub = "hide"
+			}
+			switch(subSecondary) {
+				case 'Agility':
+					setAttrs({
+						"agility_substitution": score*1,
+						"agility_display_sub_flag": sub
+					});
+					calcAgility();
+					calcOthers();
+					break;
+				case 'Fortitude':
+					setAttrs({
+						"fortitude_substitution": score*1,
+						"fortitude_display_sub_flag": sub
+					});
+					calcFortitude();
+					calcOthers();
+					break;
+				case 'Might':
+					setAttrs({
+						"might_substitution": score*1,
+						"might_display_sub_flag": sub
+					});
+					calcMight();
+					calcOthers();
+					break;
+				case 'Learning':
+					setAttrs({
+						"learning_substitution": score*1,
+						"learning_display_sub_flag": sub
+					});
+					calcLearning();
+					calcOthers();
+					break;
+				case 'Logic':
+					setAttrs({
+						"logic_substitution": score*1,
+						"logic_display_sub_flag": sub
+					});
+					calcLogic();
+					calcOthers();
+					break;
+				case 'Perception':
+					setAttrs({
+						"perception_substitution": score*1,
+						"perception_display_sub_flag": sub
+					});
+					calcPerception();
+					calcOthers();
+					break;
+				case 'Will':
+					setAttrs({
+						"will_substitution": score*1,
+						"will_display_sub_flag": sub
+					});
+					calcWill();
+					calcOthers();
+					break;
+				case 'Deception':
+					setAttrs({
+						"deception_substitution": score*1,
+						"deception_display_sub_flag": sub
+					});
+					calcDeception();
+					calcOthers();
+					break;
+				case 'Persuasion':
+					setAttrs({
+						"persuasion_substitution": score*1,
+						"persuasion_display_sub_flag": sub
+					});
+					calcPersuasion();
+					calcOthers();
+					break;
+				case 'Presence':
+					setAttrs({
+						"presence_substitution": score*1,
+						"presence_display_sub_flag": sub
+					});
+					calcPresence();
+					calcOthers();
+					break;
+				case 'Alteration':
+					setAttrs({
+						"alteration_substitution": score*1,
+						"alteration_display_sub_flag": sub
+					});
+					calcAlteration();
+					calcOthers();
+					break;
+				case 'Creation':
+					setAttrs({
+						"creation_substitution": score*1,
+						"creation_display_sub_flag": sub
+					});
+					calcCreation();
+					calcOthers();
+					break;
+				case 'Energy':
+					setAttrs({
+						"energy_substitution": score*1,
+						"energy_display_sub_flag": sub
+					});
+					calcEnergy();
+					calcOthers();
+					break;
+				case 'Entropy':
+					setAttrs({
+						"entropy_substitution": score*1,
+						"entropy_display_sub_flag": sub
+					});
+					calcEntropy();
+					calcOthers();
+					break;
+				case 'Influence':
+					setAttrs({
+						"influence_substitution": score*1,
+						"influence_display_sub_flag": sub
+					});
+					calcInfluence();
+					calcOthers();
+					break;
+				case 'Movement':
+					setAttrs({
+						"movement_substitution": score*1,
+						"movement_display_sub_flag": sub
+					});
+					calcMovement();
+					calcOthers();
+					break;
+				case 'Prescience':
+					setAttrs({
+						"prescience_substitution": score*1,
+						"prescience_display_sub_flag": sub
+					});
+					calcPrescience();
+					calcOthers();
+					break;
+				case 'Protection':
+					setAttrs({
+						"protection_substitution": score*1,
+						"protection_display_sub_flag": sub
+					});
+					calcProtection();
+					calcOthers();
+					break;
+				default:
+					break;
+			}
+        });		
+	};
 
     // Anytime Agility Substitution is selected
     on("change:agility_substitution_select", function() {
@@ -175,47 +294,10 @@ repeating_items
     });
     // Function for Agility Substitution is selected
     function calcAgilitySub() {
-        getAttrs(["agility_substitution_select", "learning_score", "logic_score", "perception_score", "will_score", "deception_score", "persuasion_score", "presence_score", "alteration_score", "creation_score", "energy_score", "entropy_score", "influence_score", "movement_score", "prescience_score", "protection_score"], function(values) {
-            var score = 0;
-            var sub = "show";
-            if(values.agility_substitution_select === "Learning") {
-                score = values.learning_score*1;
-            } else if(values.agility_substitution_select === "Logic") {
-                score = values.logic_score*1;
-            } else if(values.agility_substitution_select === "Perception") {
-                score = values.perception_score*1;
-            } else if(values.agility_substitution_select === "Will") {
-                score = values.will_score*1;
-            } else if(values.agility_substitution_select === "Deception") {
-                score = values.deception_score*1;
-            } else if(values.agility_substitution_select === "Persuasion") {
-                score = values.persuasion_score*1;
-            } else if(values.agility_substitution_select === "Presence") {
-                score = values.presence_score*1;
-            } else if(values.agility_substitution_select === "Alteration") {
-                score = values.alteration_score*1;
-            } else if(values.agility_substitution_select === "Creation") {
-                score = values.creation_score*1;
-            } else if(values.agility_substitution_select === "Energy") {
-                score = values.energy_score*1;
-            } else if(values.agility_substitution_select === "Entropy") {
-                score = values.entropy_score*1;
-            } else if(values.agility_substitution_select === "Influence") {
-                score = values.influence_score*1;
-            } else if(values.agility_substitution_select === "Movement") {
-                score = values.movement_score*1;
-            } else if(values.agility_substitution_select === "Prescience") {
-                score = values.prescience_score*1;
-            } else if(values.agility_substitution_select === "Protection") {
-                score = values.protection_score*1;
-            } else {
-                sub = "hide";
-            }
-            setAttrs({
-                "agility_substitution": score,
-                "agility_display_sub_flag": sub
-            });
+        getAttrs(["agility_substitution_select"], function(values) {
+            calcSubstitutionScore(values.agility_substitution_select, "Agility");
         });
+        calcAgility();
     };
 
     // Anytime Fortitude Substitution is selected
@@ -224,47 +306,10 @@ repeating_items
     });
     // Anytime Fortitude Substitution is selected
     function calcFortitudeSub() {
-        getAttrs(["fortitude_substitution_select", "learning_score", "logic_score", "perception_score", "will_score", "deception_score", "persuasion_score", "presence_score", "alteration_score", "creation_score", "energy_score", "entropy_score", "influence_score", "movement_score", "prescience_score", "protection_score"], function(values) {
-            var score = 0;
-            var sub = "show";
-            if(values.fortitude_substitution_select === "Learning") {
-                score = values.learning_score*1;
-            } else if(values.fortitude_substitution_select === "Logic") {
-                score = values.logic_score*1;
-            } else if(values.fortitude_substitution_select === "Perception") {
-                score = values.perception_score*1;
-            } else if(values.fortitude_substitution_select === "Will") {
-                score = values.will_score*1;
-            } else if(values.fortitude_substitution_select === "Deception") {
-                score = values.deception_score*1;
-            } else if(values.fortitude_substitution_select === "Persuasion") {
-                score = values.persuasion_score*1;
-            } else if(values.fortitude_substitution_select === "Presence") {
-                score = values.presence_score*1;
-            } else if(values.fortitude_substitution_select === "Alteration") {
-                score = values.alteration_score*1;
-            } else if(values.fortitude_substitution_select === "Creation") {
-                score = values.creation_score*1;
-            } else if(values.fortitude_substitution_select === "Energy") {
-                score = values.energy_score*1;
-            } else if(values.fortitude_substitution_select === "Entropy") {
-                score = values.entropy_score*1;
-            } else if(values.fortitude_substitution_select === "Influence") {
-                score = values.influence_score*1;
-            } else if(values.fortitude_substitution_select === "Movement") {
-                score = values.movement_score*1;
-            } else if(values.fortitude_substitution_select === "Prescience") {
-                score = values.prescience_score*1;
-            } else if(values.fortitude_substitution_select === "Protection") {
-                score = values.protection_score*1;
-            } else {
-                sub = "hide";
-            }
-            setAttrs({
-                "fortitude_substitution": score,
-                "fortitude_display_sub_flag": sub
-            });
+        getAttrs(["fortitude_substitution_select"], function(values) {
+            calcSubstitutionScore(values.fortitude_substitution_select, "Fortitude");
         });
+        calcFortitude();
     };
 
     // Anytime Might Substitution is selected
@@ -273,48 +318,223 @@ repeating_items
     });
     // Anytime Might Substitution is selected
     function calcMightSub() {
-        getAttrs(["might_substitution_select", "learning_score", "logic_score", "perception_score", "will_score", "deception_score", "persuasion_score", "presence_score", "alteration_score", "creation_score", "energy_score", "entropy_score", "influence_score", "movement_score", "prescience_score", "protection_score"], function(values) {
-            var score = 0;
-            var sub = "show";
-            if(values.might_substitution_select === "Learning") {
-                score = values.learning_score*1;
-            } else if(values.might_substitution_select === "Logic") {
-                score = values.logic_score*1;
-            } else if(values.might_substitution_select === "Perception") {
-                score = values.perception_score*1;
-            } else if(values.might_substitution_select === "Will") {
-                score = values.will_score*1;
-            } else if(values.might_substitution_select === "Deception") {
-                score = values.deception_score*1;
-            } else if(values.might_substitution_select === "Persuasion") {
-                score = values.persuasion_score*1;
-            } else if(values.might_substitution_select === "Presence") {
-                score = values.presence_score*1;
-            } else if(values.might_substitution_select === "Alteration") {
-                score = values.alteration_score*1;
-            } else if(values.might_substitution_select === "Creation") {
-                score = values.creation_score*1;
-            } else if(values.might_substitution_select === "Energy") {
-                score = values.energy_score*1;
-            } else if(values.might_substitution_select === "Entropy") {
-                score = values.entropy_score*1;
-            } else if(values.might_substitution_select === "Influence") {
-                score = values.influence_score*1;
-            } else if(values.might_substitution_select === "Movement") {
-                score = values.movement_score*1;
-            } else if(values.might_substitution_select === "Prescience") {
-                score = values.prescience_score*1;
-            } else if(values.might_substitution_select === "Protection") {
-                score = values.protection_score*1;
-            } else {
-                sub = "hide";
-            }
-            setAttrs({
-                "might_substitution": score,
-                "might_display_sub_flag": sub
-            });
+        getAttrs(["might_substitution_select"], function(values) {
+            calcSubstitutionScore(values.might_substitution_select, "Might");
         });
+        calcMight();
     };
+
+    // Anytime Deception Substitution is selected
+    on("change:deception_substitution_select", function() {
+        calcDeceptionSub();
+    });
+    // Anytime Deception Substitution is selected
+    function calcDeceptionSub() {
+        getAttrs(["deception_substitution_select"], function(values) {
+            calcSubstitutionScore(values.deception_substitution_select, "Deception");
+        });
+        calcDeception();
+    };
+
+    // Anytime Presence Substitution is selected
+    on("change:presence_substitution_select", function() {
+        calcPresenceSub();
+    });
+    // Anytime Presence Substitution is selected
+    function calcPresenceSub() {
+        getAttrs(["presence_substitution_select"], function(values) {
+            calcSubstitutionScore(values.presence_substitution_select, "Presence");
+        });
+        calcPresence();
+    };
+
+    // Anytime Persuasion Substitution is selected
+    on("changepersuasiont_substitution_select", function() {
+        calcPersuasionSub();
+    });
+    // Anytime Persuasion Substitution is selected
+    function calcPersuasionSub() {
+        getAttrs(["persuasion_substitution_select"], function(values) {
+            calcSubstitutionScore(values.persuasion_substitution_select, "Persuasion");
+        });
+        calcPersuasion();
+    };
+
+    // Anytime Learning Substitution is selected
+    on("change:learning_substitution_select", function() {
+        calcLearningSub();
+    });
+    // Anytime Learning Substitution is selected
+    function calcLearningSub() {
+        getAttrs(["learning_substitution_select"], function(values) {
+            calcSubstitutionScore(values.learning_substitution_select, "Learning");
+        });
+        calcLearning();
+    };
+
+    // Anytime Logic Substitution is selected
+    on("change:logic_substitution_select", function() {
+        calcLogicSub();
+    });
+    // Anytime Logic Substitution is selected
+    function calcLogicSub() {
+        getAttrs(["logic_substitution_select"], function(values) {
+            calcSubstitutionScore(values.logic_substitution_select, "Logic");
+        });
+        calcLogic();
+    };
+
+    // Anytime Perception Substitution is selected
+    on("change:perception_substitution_select", function() {
+        calcPerceptionSub();
+    });
+    // Anytime Perception Substitution is selected
+    function calcPerceptionSub() {
+        getAttrs(["perception_substitution_select"], function(values) {
+            calcSubstitutionScore(values.perception_substitution_select, "Perception");
+        });
+        calcPerception();
+    };
+
+    // Anytime Will Substitution is selected
+    on("change:will_substitution_select", function() {
+        calcWillSub();
+    });
+    // Anytime Will Substitution is selected
+    function calcWillSub() {
+        getAttrs(["will_substitution_select"], function(values) {
+            calcSubstitutionScore(values.will_substitution_select, "Will");
+        });
+        calcWill();
+    };
+
+    // Anytime Alteration Substitution is selected
+    on("change:alteration_substitution_select", function() {
+        calcAlterationSub();
+    });
+    // Anytime Alteration Substitution is selected
+    function calcAlterationSub() {
+        getAttrs(["alteration_substitution_select"], function(values) {
+            calcSubstitutionScore(values.alteration_substitution_select, "Alteration");
+        });
+        calcAlteration();
+    };
+
+    // Anytime Creation Substitution is selected
+    on("change:creation_substitution_select", function() {
+        calcCreationSub();
+    });
+    // Anytime Creation Substitution is selected
+    function calcCreationSub() {
+        getAttrs(["creation_substitution_select"], function(values) {
+            calcSubstitutionScore(values.creation_substitution_select, "Creation");
+        });
+        calcCreation();
+    };
+
+    // Anytime Energy Substitution is selected
+    on("change:energy_substitution_select", function() {
+        calcEnergySub();
+    });
+    // Anytime Energy Substitution is selected
+    function calcEnergySub() {
+        getAttrs(["energy_substitution_select"], function(values) {
+            calcSubstitutionScore(values.energy_substitution_select, "Energy");
+        });
+        calcEnergy();
+    };
+
+    // Anytime Entropy Substitution is selected
+    on("change:entropy_substitution_select", function() {
+        calcEntropySub();
+    });
+    // Anytime Entropy Substitution is selected
+    function calcEntropySub() {
+        getAttrs(["entropy_substitution_select"], function(values) {
+            calcSubstitutionScore(values.entropy_substitution_select, "Entropy");
+        });
+        calcEntropy();
+    };
+
+    // Anytime Influence Substitution is selected
+    on("change:influence_substitution_select", function() {
+        calcInfluenceSub();
+    });
+    // Anytime Influence Substitution is selected
+    function calcInfluenceSub() {
+        getAttrs(["influence_substitution_select"], function(values) {
+            calcSubstitutionScore(values.influence_substitution_select, "Influence");
+        });
+        calcInfluence();
+    };
+
+    // Anytime Movement Substitution is selected
+    on("change:movement_substitution_select", function() {
+        calcMovementSub();
+    });
+    // Anytime Movement Substitution is selected
+    function calcMovementSub() {
+        getAttrs(["movement_substitution_select"], function(values) {
+            calcSubstitutionScore(values.movement_substitution_select, "Movement");
+        });
+        calcMovement();
+    };
+
+    // Anytime Prescience Substitution is selected
+    on("change:prescience_substitution_select", function() {
+        calcPrescienceSub();
+    });
+    // Anytime Prescience Substitution is selected
+    function calcPrescienceSub() {
+        getAttrs(["prescience_substitution_select"], function(values) {
+            calcSubstitutionScore(values.prescience_substitution_select, "Prescience");
+        });
+        calcPrescience();
+    };
+
+    // Anytime Protection Substitution is selected
+    on("change:protection_substitution_select", function() {
+        calcProtectionSub();
+    });
+    // Anytime Protection Substitution is selected
+    function calcProtectionSub() {
+        getAttrs(["protection_substitution_select"], function(values) {
+            calcSubstitutionScore(values.protection_substitution_select, "Protection");
+        });
+        calcProtection();
+    };
+
+	// Update All Attributes when any are changed (have to b/c of attribute substitution)
+	function calcAttributes() {
+		calcAgilitySub();
+		calcFortitudeSub();
+		calcMightSub();
+		calcDeceptionSub();
+		calcPresenceSub();
+		calcPersuasionSub();
+		calcLearningSub();
+		calcLogicSub();
+		calcPerceptionSub();
+		calcWillSub();
+		calcAlterationSub();
+		calcCreationSub();
+		calcEnergySub();
+		calcEntropySub();
+		calcInfluenceSub();
+		calcMovementSub();
+		calcPrescienceSub();
+		calcProtectionSub();
+		calcOthers();
+	};
+	
+	function calcOthers() {
+		calcEvasion();
+		calcToughness();
+		calcResolve();
+		calcHeavy();
+		calcHitPoints();
+		calcAllActionRolls();
+	};
 
     // Function to calculate Evasion, called when changes made to Armor, Shield, Agility, or evasion other
     function calcEvasion() {
@@ -338,15 +558,20 @@ repeating_items
     
     // Function to calculate Toughness, called when changes made to Armor, Shield, Fortitude, or toughness other
     function calcToughness() {
-        getAttrs(["fortitude_score", "fortitude_substitution", "will_score", "toughness_other"], function(values) {
+        getAttrs(["fortitude_score", "fortitude_substitution", "will_score", "will_substitution", "toughness_other"], function(values) {
             var score = 0;
             if (values.fortitude_score*1 >= values.fortitude_substitution*1) {
                 score = values.fortitude_score*1;
             } else {
                 score = values.fortitude_substitution*1;
             }
+            if (values.will_score*1 >= values.will_substitution*1) {
+                score += values.will_score*1;
+            } else {
+                score += values.will_substitution*1;
+            }
             setAttrs({
-                "toughness": score + values.will_score*1 + values.toughness_other*1 + 10
+                "toughness": score + values.toughness_other*1 + 10
             });
         });
     };
@@ -358,9 +583,20 @@ repeating_items
     
     // Function to calculate Resolve, called when changes made to presence, will, or resolve other
     function calcResolve() {
-        getAttrs(["presence_score", "will_score", "resolve_other"], function(values) {
+        getAttrs(["presence_score", "presence_substitution", "will_score", "will_substitution", "resolve_other"], function(values) {
+            var score = 0;
+            if (values.presence_score*1 >= values.presence_substitution*1) {
+                score = values.presence_score*1;
+            } else {
+                score = values.presence_substitution*1;
+            }
+            if (values.will_score*1 >= values.will_substitution*1) {
+                score += values.will_score*1;
+            } else {
+                score += values.will_substitution*1;
+            }
             setAttrs({
-                "resolve": values.presence_score*1 + values.will_score*1 + values.resolve_other*1 + 10
+                "resolve": score + values.resolve_other*1 + 10
             });
         });
     };
@@ -480,15 +716,25 @@ repeating_items
     
     // Function to calc HIt points, called when changes to fortitude, presence or will
     function calcHitPoints() {
-        getAttrs(["fortitude_score", "fortitude_substitution", "presence_score", "will_score", "lethal_damage", "hit_point_feats", "hit_point_other"], function(values) {
+        getAttrs(["fortitude_score", "fortitude_substitution", "presence_score", "presence_substitution", "will_score", "will_substitution", "lethal_damage", "hit_point_feats", "hit_point_other"], function(values) {
             var score = 0;
             if(values.fortitude_score*1 >= values.fortitude_substitution*1) {
                 score = values.fortitude_score*1;
             } else {
                 score = values.fortitude_substitution*1;
             }
+            if (values.presence_score*1 >= values.presence_substitution*1) {
+                score += values.presence_score*1;
+            } else {
+                score += values.presence_substitution*1;
+            }
+            if (values.will_score*1 >= values.will_substitution*1) {
+                score += values.will_score*1;
+            } else {
+                score += values.will_substitution*1;
+            }
             setAttrs({
-                "hit_point_max": 2*(score + values.presence_score*1 + values.will_score*1) + 10 - values.lethal_damage*1 + values.hit_point_feats*1 + values.hit_point_other*1
+                "hit_point_max": 2*(score) + 10 - values.lethal_damage*1 + values.hit_point_feats*1 + values.hit_point_other*1
             });
         });
     };
@@ -511,15 +757,12 @@ repeating_items
     
     // Anytime Agility score is changed, update cost and dice
     on("change:agility_score change:agility_dice_d20 change:agility_cost_modifier change:agility_dice_modifier", function() {
-        calcAgility();
-        calcEvasion();                  // call to recalculate evasion score
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Agility
 	function calcAgility() {
-        calcAgilitySub();
-        getAttrs(["agility_score", "agility_dice_d20", "agility_cost_modifier", "agility_dice_modifier"], function(values) {
+        getAttrs(["agility_score", "agility_substitution", "agility_dice_d20", "agility_cost_modifier", "agility_dice_modifier"], function(values) {
             var score = values.agility_score*1 + values.agility_dice_modifier*1;
             var scoreCost = values.agility_score*1 + values.agility_cost_modifier*1;
             var number = calcAttributeDiceNumber(score);
@@ -527,6 +770,12 @@ repeating_items
             var dice = number + type;
 			var roll = "";
 			var rollInitiative = "";
+			var display = 0;
+			if(values.agility_score*1 >= values.agility_substitution*1) {
+				display = values.agility_score*1;
+			} else {
+				display = values.agility_substitution*1;
+			}
 			if(score === 0) {
 				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]";
 				rollInitiative = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}&{tracker}]]";
@@ -538,7 +787,8 @@ repeating_items
                 "agility_cost": (scoreCost*1 * (scoreCost*1 + 1))/2,
                 "agility_dice_roll": roll,
                 "agility_dice": dice,
-                "agility_initiative": rollInitiative
+                "agility_initiative": rollInitiative,
+				"agility_display": display
             });
             calcAttributePointsSpent();     // call to recalculate total costs, needs to be after new cost is set in setAttrs
         });
@@ -546,22 +796,24 @@ repeating_items
     
     // Anytime fortitude score is changed, update cost and dice
     on("change:fortitude_score change:fortitude_dice_d20 change:fortitude_cost_modifier change:fortitude_dice_modifier", function() {
-		calcFortitude();
-        calcToughness();                // call to recalute toughness
-        calcHitPoints();                // call to update hitpoints
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Fortitude
 	function calcFortitude() {
-        calcFortitudeSub();
-        getAttrs(["fortitude_score", "fortitude_dice_d20", "fortitude_cost_modifier", "fortitude_dice_modifier"], function(values) {
+        getAttrs(["fortitude_score", "fortitude_substitution", "fortitude_dice_d20", "fortitude_cost_modifier", "fortitude_dice_modifier"], function(values) {
             var score = values.fortitude_score*1 + values.fortitude_dice_modifier*1;
             var scoreCost = values.fortitude_score*1 + values.fortitude_cost_modifier*1;
             var number = calcAttributeDiceNumber(score);
             var type = calcAttributeDiceType(score);
             var dice = number + type;
 			var roll = "";
+			var display = 0;
+			if(values.fortitude_score*1 >= values.fortitude_substitution*1) {
+				display = values.fortitude_score*1;
+			} else {
+				display = values.fortitude_substitution*1;
+			}
 			if(score === 0) {
 				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]";
 			} else {
@@ -570,7 +822,8 @@ repeating_items
             setAttrs({
                 "fortitude_cost": (scoreCost*1 * (scoreCost*1 + 1))/2,
                 "fortitude_dice_roll": roll,
-                "fortitude_dice": dice
+                "fortitude_dice": dice,
+				"fortitude_display": display
             });
             calcAttributePointsSpent();     // call to recalculate total costs, needs to be after new cost is set in setAttrs
         });
@@ -578,22 +831,24 @@ repeating_items
     
     // Anytime might score is changed, update cost and dice
     on("change:might_score change:might_dice_d20 change:might_cost_modifier change:might_dice_modifier", function() {
-		calcMight();
-		calcHeavy();
-		calcEvasion();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Might
 	function calcMight() {
-        calcMightSub();
-        getAttrs(["might_score", "might_dice_d20", "might_cost_modifier", "might_dice_modifier"], function(values) {
+        getAttrs(["might_score", "might_substitution", "might_dice_d20", "might_cost_modifier", "might_dice_modifier"], function(values) {
             var score = values.might_score*1 + values.might_dice_modifier*1;
             var scoreCost = values.might_score*1 + values.might_cost_modifier*1;
             var number = calcAttributeDiceNumber(score);
             var type = calcAttributeDiceType(score);
             var dice = number + type;
 			var roll = "";
+			var display = 0;
+			if(values.might_score*1 >= values.might_substitution*1) {
+				display = values.might_score*1;
+			} else {
+				display = values.might_substitution*1;
+			}
 			if(score === 0) {
 				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]";
 			} else {
@@ -602,7 +857,8 @@ repeating_items
             setAttrs({
                 "might_cost": (scoreCost*1 * (scoreCost*1 + 1))/2,
                 "might_dice_roll": roll,
-                "might_dice": dice
+                "might_dice": dice,
+				"might_display": display
             });
             calcAttributePointsSpent();     // call to recalculate total costs, needs to be after new cost is set in setAttrs
         });
@@ -610,11 +866,7 @@ repeating_items
     
     // Anytime deception score is changed, update cost and dice
     on("change:deception_score change:deception_dice_d20 change:deception_cost_modifier change:deception_dice_modifier", function() {
-		calcDeception();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Deception
@@ -642,23 +894,24 @@ repeating_items
 	
     // Anytime presence score is changed, update cost and dice
     on("change:presence_score change:presence_dice_d20 change:presence_cost_modifier change:presence_dice_modifier", function() {
-		calcPresence();
-		calcResolve();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Presence
 	function calcPresence() {
-        getAttrs(["presence_score", "presence_dice_d20", "presence_cost_modifier", "presence_dice_modifier"], function(values) {
+        getAttrs(["presence_score", "presence_substitution", "presence_dice_d20", "presence_cost_modifier", "presence_dice_modifier"], function(values) {
             var score = values.presence_score*1 + values.presence_dice_modifier*1;
             var scoreCost = values.presence_score*1 + values.presence_cost_modifier*1;
             var number = calcAttributeDiceNumber(score);
             var type = calcAttributeDiceType(score);
             var dice = number + type;
 			var roll = "";
+			var display = 0;
+			if(values.presence_score*1 >= values.presence_substitution*1) {
+				display = values.presence_score*1;
+			} else {
+				display = values.presence_substitution*1;
+			}
 			if(score === 0) {
 				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]";
 			} else {
@@ -667,7 +920,8 @@ repeating_items
             setAttrs({
                 "presence_cost": (scoreCost*1 * (scoreCost*1 + 1))/2,
                 "presence_dice_roll": roll,
-                "presence_dice": dice
+                "presence_dice": dice,
+				"presence_display": display
             });
             calcAttributePointsSpent();     // call to recalculate total costs, needs to be after new cost is set in setAttrs
         });
@@ -675,11 +929,7 @@ repeating_items
     
     // Anytime persuasion score is changed, update cost and dice
     on("change:persuasion_score change:persuasion_dice_d20 change:persuasion_cost_modifier change:persuasion_dice_modifier", function() {
-		calcPersuasion();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Persuasion
@@ -707,11 +957,7 @@ repeating_items
     
     // Anytime learning score is changed, update cost and dice
     on("change:learning_score change:learning_dice_d20 change:learning_cost_modifier change:learning_dice_modifier", function() {
-		calcLearning();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Learning
@@ -739,11 +985,7 @@ repeating_items
 	
     // Anytime logic score is changed, update cost and dice
     on("change:logic_score change:logic_dice_d20 change:logic_cost_modifier change:logic_dice_modifier", function() {
-		calcLogic();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Logic
@@ -771,11 +1013,7 @@ repeating_items
     
     // Anytime perception score is changed, update cost and dice
     on("change:perception_score change:perception_dice_d20 change:perception_cost_modifier change:perception_dice_modifier", function() {
-		calcPerception();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Perception
@@ -803,23 +1041,24 @@ repeating_items
 	
     // Anytime will score is changed, update cost and dice
     on("change:will_score change:will_dice_d20 change:will_cost_modifier change:will_dice_modifier", function() {
-		calcWill();
-        calcResolve();                  // call to recalculate resolve
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Will
 	function calcWill() {
-        getAttrs(["will_score", "will_dice_d20", "will_cost_modifier", "will_dice_modifier"], function(values) {
+        getAttrs(["will_score", "will_substitution", "will_dice_d20", "will_cost_modifier", "will_dice_modifier"], function(values) {
             var score = values.will_score*1 + values.will_dice_modifier*1;
             var scoreCost = values.will_score*1 + values.will_cost_modifier*1;
             var number = calcAttributeDiceNumber(score);
             var type = calcAttributeDiceType(score);
             var dice = number + type;
 			var roll = "";
+			var display = 0;
+			if(values.will_score*1 >= values.will_substitution*1) {
+				display = values.will_score*1;
+			} else {
+				display = values.will_substitution*1;
+			}
 			if(score === 0) {
 				roll = "[[?{Do you have Advantage or Disadvantage?|Neither,1d20!!|Advantage,2d20!!kh1|Disadvantage,2d20!!kl1}]]";
 			} else {
@@ -828,7 +1067,8 @@ repeating_items
             setAttrs({
                 "will_cost": (scoreCost*1 * (scoreCost*1 + 1))/2,
                 "will_dice_roll": roll,
-                "will_dice": dice
+                "will_dice": dice,
+				"will_display": display
             });
             calcAttributePointsSpent();     // call to recalculate total costs, needs to be after new cost is set in setAttrs
         });
@@ -836,11 +1076,7 @@ repeating_items
 	
     // Anytime alteration score is changed, update cost and dice
     on("change:alteration_score change:alteration_dice_d20 change:alteration_cost_modifier change:alteration_dice_modifier", function() {
-		calcAlteration();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Alteration
@@ -868,11 +1104,7 @@ repeating_items
 	
     // Anytime creation score is changed, update cost and dice
     on("change:creation_score change:creation_dice_d20 change:creation_cost_modifier change:creation_dice_modifier", function() {
-		calcCreation();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Creation
@@ -900,11 +1132,7 @@ repeating_items
 	
     // Anytime energy score is changed, update cost and dice
     on("change:energy_score change:energy_dice_d20 change:energy_cost_modifier change:energy_dice_modifier", function() {
-		calcEnergy();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Energy
@@ -932,11 +1160,7 @@ repeating_items
 	
     // Anytime entropy score is changed, update cost and dice
     on("change:entropy_score change:entropy_dice_d20 change:entropy_cost_modifier change:entropy_dice_modifier", function() {
-		calcEntropy();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Entropy
@@ -964,11 +1188,7 @@ repeating_items
 	
     // Anytime influence score is changed, update cost and dice
     on("change:influence_score change:influence_dice_d20 change:influence_cost_modifier change:influence_dice_modifier", function() {
-		calcInfluence();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Influence
@@ -996,11 +1216,7 @@ repeating_items
 
     // Anytime movement score is changed, update cost and dice
     on("change:movement_score change:movement_dice_d20 change:movement_cost_modifier change:movement_dice_modifier", function() {
-		calcMovement();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Movement
@@ -1028,11 +1244,7 @@ repeating_items
 
 	// Anytime prescience score is changed, update cost and dice
     on("change:prescience_score change:prescience_dice_d20 change:prescience_cost_modifier change:prescience_dice_modifier", function() {
-		calcPrescience();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Protection
@@ -1060,11 +1272,7 @@ repeating_items
 
 	// Anytime protection score is changed, update cost and dice
     on("change:protection_score change:protection_dice_d20 change:protection_cost_modifier change:protection_dice_modifier", function() {
-		calcProtection();
-        calcAgility();
-        calcFortitude();
-        calcMight();
-        calcAllActionRolls();
+        calcAttributes();
     });
 	
 	// Function for calculating everything to do with Protection
@@ -2325,7 +2533,7 @@ var TAS = TAS || (function(){
 <!-- Main body of Character Sheet -->
 <div class="container">     <!-- defines the width/height & behavior of the page -->
     <div class="row width100 padBottom">
-        <div class="column textSmall textRight padRight">2017.01.04 <span class="bold">Version 1.7.5 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
+        <div class="column textSmall textRight padRight">2017.02.06 <span class="bold">Version 1.7.7 </span> <input class="settings" type="checkbox" name="attr_sheet_settings_flag" value="hide" /><span>y</span></div>
     </div>
     <div class="row width100">
         <div class="column width10 inlineBlock textSmall bold">Character Info</div>
@@ -2443,7 +2651,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="agility_display_settings_flag" name="attr_agility_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Dodge attacks, move with stealth, perform acrobatics, shoot a bow, pick a pocket</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_agility_cost_modifier" value=0 /></div>
@@ -2459,6 +2667,8 @@ var TAS = TAS || (function(){
                 <div class="column width40 inlineBlock inputSelect">
                     <select name="attr_agility_substitution_select">
                         <option value="None" selected="selected">None</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
                         <option value="Learning">Learning</option>
                         <option value="Logic">Logic</option>
                         <option value="Perception">Perception</option>
@@ -2477,7 +2687,8 @@ var TAS = TAS || (function(){
                     </select>
                 </div>
                 <input type="hidden" name="attr_agility_substitution" value=0 />
-                <div class="column width100 bold italic">For ACTIONS, select the substituted attribute instead of Agility.</div>
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION, select the substituted attribute instead of Agility.</div>
             </div>
         </div>
       <!-- Fortitude -->
@@ -2495,8 +2706,8 @@ var TAS = TAS || (function(){
             </div>
             <input type="hidden" class="fortitude_display_settings_flag" name="attr_fortitude_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Resist poison, shrug off pain, exert yourself physically</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Resist poison, shrug off pain, exert yourself physically, wear heavy armor</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_fortitude_cost_modifier" value=0 /></div>
@@ -2512,6 +2723,8 @@ var TAS = TAS || (function(){
                 <div class="column width40 inlineBlock inputSelect">
                     <select name="attr_fortitude_substitution_select">
                         <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Might">Might</option>
                         <option value="Learning">Learning</option>
                         <option value="Logic">Logic</option>
                         <option value="Perception">Perception</option>
@@ -2530,7 +2743,8 @@ var TAS = TAS || (function(){
                     </select>
                 </div>
                 <input type="hidden" name="attr_fortitude_substitution" value=0 />
-                <div class="column width100 bold italic">For ACTIONS, select the substituted attribute instead of Fortitude.</div>
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Might -->
@@ -2548,8 +2762,8 @@ var TAS = TAS || (function(){
             </div>
             <input type="hidden" class="might_display_settings_flag" name="attr_might_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
-                <div class="column width95 inlineBlock boxShadow textSmall">Wear heavy armor, swing a maul, jump over a chasm, break down a door, wrestle a foe to submission</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width95 inlineBlock boxShadow textSmall">Shake off attacks, swing a maul, jump over a chasm, break down a door, wrestle a foe to submission</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_might_cost_modifier" value=0 /></div>
@@ -2565,6 +2779,8 @@ var TAS = TAS || (function(){
                 <div class="column width40 inlineBlock inputSelect">
                     <select name="attr_might_substitution_select">
                         <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
                         <option value="Learning">Learning</option>
                         <option value="Logic">Logic</option>
                         <option value="Perception">Perception</option>
@@ -2585,7 +2801,8 @@ var TAS = TAS || (function(){
                 <input type="hidden" name="attr_might_substitution" value=0 />
                 <div class="column width90 inlineBlock">Substitution affects Max Heavy Carry</div>
                 <div class="column width10 inlineBlock"><input type="checkbox" class="checks25" name="attr_might_substitution_heavy" /></div>
-                <div class="column width100 bold italic">For ACTIONS, select the substituted attribute instead of Might.</div>
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION, select the substituted attribute instead of Might.</div>
             </div>
         </div>
     <!-- end of physical attributes -->
@@ -2603,7 +2820,8 @@ var TAS = TAS || (function(){
       <!-- Deception -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_deception_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="deception_display_sub_flag" name="attr_deception_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Deception Roll}} {{subTitle= @{character_name}}} {{roll= @{deception_dice_roll}}}">Deception</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2615,7 +2833,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="deception_display_settings_flag" name="attr_deception_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Tell a lie, bluff at cards, disguise yourself, spread rumors, swindle a sucker</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_deception_cost_modifier" value=0 /></div>
@@ -2627,12 +2845,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_deception_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_deception_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Presence -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_presence_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="presence_display_sub_flag" name="attr_presence_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Presence Roll}} {{subTitle= @{character_name}}} {{roll= @{presence_dice_roll}}}">Presence</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2644,7 +2889,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="presence_display_settings_flag" name="attr_presence_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Give a speech, sing a song, inspire an army, exert your force of personality, have luck smile upon you</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_presence_cost_modifier" value=0 /></div>
@@ -2656,12 +2901,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_presence_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_presence_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Persuasion -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_persuasion_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="persuasion_display_sub_flag" name="attr_persuasion_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Persuasion Roll}} {{subTitle= @{character_name}}} {{roll= @{persuasion_dice_roll}}}">Persuasion</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2673,7 +2945,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="persuasion_display_settings_flag" name="attr_persuasion_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Negotiate a deal, convince someone, haggle a good price, pry information</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_persuasion_cost_modifier" value=0 /></div>
@@ -2685,6 +2957,32 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_persuasion_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_persuasion_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
     <!-- end of Social attributes -->
@@ -2702,7 +3000,8 @@ var TAS = TAS || (function(){
       <!-- Learning -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_learning_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="learning_display_sub_flag" name="attr_learning_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Learning Roll}} {{subTitle= @{character_name}}} {{roll= @{learning_dice_roll}}}">Learning</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2714,7 +3013,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="learning_display_settings_flag" name="attr_learning_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Recall facts about history, arcane magic, the natural world, etc.</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_learning_cost_modifier" value=0 /></div>
@@ -2726,12 +3025,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_learning_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_learning_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Logic -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_logic_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="logic_display_sub_flag" name="attr_logic_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Logic Roll}} {{subTitle= @{character_name}}} {{roll= @{logic_dice_roll}}}">Logic</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2743,7 +3069,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="logic_display_settings_flag" name="attr_logic_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Solve riddles, decipher a code, improvise a tool, understand the enemy’s strategy, find a loophole</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_logic_cost_modifier" value=0 /></div>
@@ -2755,12 +3081,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_logic_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_logic_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Perception -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_perception_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="perception_display_sub_flag" name="attr_perception_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Perception Roll}} {{subTitle= @{character_name}}} {{roll= @{perception_dice_roll}}}">Perception</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2772,7 +3125,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="perception_display_settings_flag" name="attr_perception_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Sense ulterior motives, track someone, catch a gut feeling, spot a hidden foe, find a secret door</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_perception_cost_modifier" value=0 /></div>
@@ -2784,12 +3137,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_perception_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_perception_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Will -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_will_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="will_display_sub_flag" name="attr_will_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Will Roll}} {{subTitle= @{character_name}}} {{roll= @{will_dice_roll}}}">Will</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2801,7 +3181,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="will_display_settings_flag" name="attr_will_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Maintain your resolve, overcome adversity, resist torture, stay awake on watch, stave off insanity</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_will_cost_modifier" value=0 /></div>
@@ -2813,6 +3193,32 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_will_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_will_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
     <!-- end mental attributes -->
@@ -2830,7 +3236,8 @@ var TAS = TAS || (function(){
       <!-- Alteration -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_alteration_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="alteration_display_sub_flag" name="attr_alteration_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Alteration Roll}} {{subTitle= @{character_name}}} {{roll= @{alteration_dice_roll}}}">Alteration</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2842,7 +3249,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="alteration_display_settings_flag" name="attr_alteration_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Change shape, alter molecular structures, transmute one material into another</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_alteration_cost_modifier" value=0 /></div>
@@ -2854,12 +3261,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_alteration_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_alteration_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Creation -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_creation_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="creation_display_sub_flag" name="attr_creation_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Creation Roll}} {{subTitle= @{character_name}}} {{roll= @{creation_dice_roll}}}">Creation</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2871,7 +3305,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="creation_display_settings_flag" name="attr_creation_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Channeling higher powers for healing, creation, resurrection, divine might, etc.</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_creation_cost_modifier" value=0 /></div>
@@ -2883,12 +3317,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_creation_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_creation_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Energy -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_energy_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="energy_display_sub_flag" name="attr_energy_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Energy Roll}} {{subTitle= @{character_name}}} {{roll= @{energy_dice_roll}}}">Energy</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2900,7 +3361,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="energy_display_settings_flag" name="attr_energy_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Create and control the elements–fire, cold, electricity, etc.</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_energy_cost_modifier" value=0 /></div>
@@ -2912,12 +3373,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_energy_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_energy_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Entropy -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_entropy_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="entropy_display_sub_flag" name="attr_entropy_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Entropy Roll}} {{subTitle= @{character_name}}} {{roll= @{entropy_dice_roll}}}">Entropy</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2929,7 +3417,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="entropy_display_settings_flag" name="attr_entropy_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Disintegrate matter, kill with a word, create undead, sicken others</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_entropy_cost_modifier" value=0 /></div>
@@ -2941,12 +3429,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_entropy_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_entropy_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Influence -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_influence_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="influence_display_sub_flag" name="attr_influence_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Influence Roll}} {{subTitle= @{character_name}}} {{roll= @{influence_dice_roll}}}">Influence</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2958,7 +3473,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="influence_display_settings_flag" name="attr_influence_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Control the minds of others, speak telepathically, instill supernatural fear, create illusory figments, cloak with invisibility</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_influence_cost_modifier" value=0 /></div>
@@ -2970,12 +3485,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_influence_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_influence_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Movement -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_movement_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="movement_display_sub_flag" name="attr_movement_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Movement Roll}} {{subTitle= @{character_name}}} {{roll= @{movement_dice_roll}}}">Movement</button>
             </div>
             <div class="width55 inlineBlock">
@@ -2987,7 +3529,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="movement_display_settings_flag" name="attr_movement_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Teleport, fly, hasten, slow</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_movement_cost_modifier" value=0 /></div>
@@ -2999,12 +3541,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_movement_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Prescience">Prescience</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_movement_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Prescience -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_prescience_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="prescience_display_sub_flag" name="attr_prescience_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Prescience Roll}} {{subTitle= @{character_name}}} {{roll= @{prescience_dice_roll}}}">Prescience</button>
             </div>
             <div class="width55 inlineBlock">
@@ -3016,7 +3585,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="prescience_display_settings_flag" name="attr_prescience_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">See the future, read minds or auras, detect magic or evil, scry, communicate with extraplanar entities</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_prescience_cost_modifier" value=0 /></div>
@@ -3028,12 +3597,39 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_prescience_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Protection">Protection</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_prescience_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
       <!-- Protection -->
         <div class="row width100">
             <div class="width6 inlineBlock vertBottom"><input class="settings" type="checkbox" name="attr_protection_settings_flag" value="on" /><span>y</span></div>
-            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton">
+            <input type="hidden" class="protection_display_sub_flag" name="attr_protection_display_sub_flag" value="hide" />
+            <div class="column width39 inlineBlock textLeft textLarge bold italic attributeButton sub">
                 <button type="roll" value="&{template:openLegend} {{title= Protection Roll}} {{subTitle= @{character_name}}} {{roll= @{protection_dice_roll}}}">Protection</button>
             </div>
             <div class="width55 inlineBlock">
@@ -3045,7 +3641,7 @@ var TAS = TAS || (function(){
             <input type="hidden" class="protection_display_settings_flag" name="attr_protection_display_settings_flag" value="hide" />
             <div class="width100 displaySettings padBottom">
                 <div class="column width95 inlineBlock boxShadow textSmall">Protect from damage, break supernatural influence, dispel magic, bind demons</div>
-                <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_dice_modifier" value=0 /></div>
                 <div class="column width75 inlineBlock">Increase/Decrease cost in levels:</div>
                 <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_protection_cost_modifier" value=0 /></div>
@@ -3057,6 +3653,32 @@ var TAS = TAS || (function(){
                         <option value="2d20!!kl1">Disadvantage</option>
                     </select>
                 </div>
+                <div class="column width60 inlineBlock">Attribute Substitution:</div>
+                <div class="column width40 inlineBlock inputSelect">
+                    <select name="attr_protection_substitution_select">
+                        <option value="None" selected="selected">None</option>
+                        <option value="Agility">Agility</option>
+                        <option value="Fortitude">Fortitude</option>
+                        <option value="Might">Might</option>
+                        <option value="Learning">Learning</option>
+                        <option value="Logic">Logic</option>
+                        <option value="Perception">Perception</option>
+                        <option value="Will">Will</option>
+                        <option value="Deception">Deception</option>
+                        <option value="Persuasion">Persuasion</option>
+                        <option value="Presence">Presence</option>
+                        <option value="Alteration">Alteration</option>
+                        <option value="Creation">Creation</option>
+                        <option value="Energy">Energy</option>
+                        <option value="Entropy">Entropy</option>
+                        <option value="Influence">Influence</option>
+                        <option value="Movement">Movement</option>
+                        <option value="Prescience">Prescience</option>
+                    </select>
+                </div>
+                <input type="hidden" name="attr_protection_substitution" value=0 />
+                <div class="column width100 bold italic">For Tier II of Attribute Substituation</div>
+				<div class="column width100 italic">In the ACTIONS SECTION(s), select the substituted attribute instead of Fortitude.</div>
             </div>
         </div>
     <!-- end of EXTRAORDINARY attributes -->
@@ -3066,7 +3688,7 @@ var TAS = TAS || (function(){
  <!-- Middle column for defenses & actions -->
     <input type="hidden" class="display_defenses_flag" name="attr_display_defenses_flag" value="show" />
     <div class="third inlineBlock vertTop displayDefenses">
-   <!-- Evasion information -->
+   <!-- Guard information -->
         <div class="width100 padAll">
             <div class="evasion vertTop padTop">
                 <div class="inlineBlock vertTop padTop" style="width: 155px;">
@@ -3078,9 +3700,11 @@ var TAS = TAS || (function(){
                 <div class="inlineBlock vertTop" style="width: 120px;">
                     <div class="width100">
                         <div class="column width100 height5"></div>
-                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_agility_score" value="@{agility_score}" disabled="disabled" /></div>
+						<input type="hidden" name="attr_agility_display" value=0 />
+                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_agility_score" value="@{agility_display}" disabled="disabled" /></div>
                         <div class="column width2of3 italic bold textLarge textLeft inlineBlock">Agility</div>
-                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_might_score" value="@{might_score}" disabled="disabled" /></div>
+						<input type="hidden" name="attr_might_display" value=0 />
+                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_might_score" value="@{might_display}" disabled="disabled" /></div>
                         <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Might</div>
                         <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_armor" value=0 /></div>
                         <div class="column width2of3 italic bold textLarge padTop textLeft inlineBlock">Armor</div>
@@ -3093,7 +3717,7 @@ var TAS = TAS || (function(){
                 </div>
             </div>
         </div>
-   <!-- End evasion -->
+   <!-- End Guard -->
    <!-- Toughness information -->
         <div class="width100 padAll">
             <div class="toughness vertTop padTop">
@@ -3105,9 +3729,11 @@ var TAS = TAS || (function(){
                 </div>
                 <div class="inlineBlock vertTop" style="width: 120px;">
                     <div class="width100 padTop">
-                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_fortitude_score" value="@{fortitude_score}" disabled="true" /></div>
+						<input type="hidden" name="attr_fortitude_display" value=0 />
+                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_fortitude_score" value="@{fortitude_display}" disabled="true" /></div>
                         <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Fortitude</div>
-                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_score}" disabled="true" /></div>
+						<input type="hidden" name="attr_will_display" value=0 />
+                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_display}" disabled="true" /></div>
                         <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Will</div>
                         <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_toughness_other" value="0" /></div>
                         <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Other</div>
@@ -3127,9 +3753,10 @@ var TAS = TAS || (function(){
                 </div>
                 <div class="inlineBlock vertTop" style="width: 120px;">
                     <div class="width100 padTop">
-                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_presence_score" value="@{presence_score}" disabled="true" /></div>
+						<input type="hidden" name="attr_presence_display" value=0 />
+                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_presence_score" value="@{presence_display}" disabled="true" /></div>
                         <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Presence</div>
-                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_score}" disabled="true" /></div>
+                        <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_show_will_score" value="@{will_display}" disabled="true" /></div>
                         <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Will</div>
                         <div class="column width1of3 inputNumber30 inlineBlock"><input type="number" name="attr_resolve_other" value="0" /></div>
                         <div class="column width2of3 italic bold textLarge textLeft inlineBlock padTop">Other</div>
@@ -3245,13 +3872,13 @@ var TAS = TAS || (function(){
                             <div class="column width45 inlineBlock inputSelect">
                                 <select name="attr_action_target">
                                     <option value="None" selected="selected">None</option>
-                                    <option value="Evasion">Evasion</option>
+                                    <option value="Guard">Guard</option>
                                     <option value="Toughness">Toughness</option>
                                     <option value="Resolve">Resolve</option>
                                 </select>
                             </div>
                             <input type="hidden" name="attr_dice_roll" value=0 />
-                            <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                            <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                             <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
                             <div class="column width55 inlineBlock">d20 for this action is:</div>
                             <input type="hidden" name="attr_dice_d20" value="1d20!!" />
@@ -3331,13 +3958,13 @@ var TAS = TAS || (function(){
                             <div class="column width45 inlineBlock inputSelect">
                                 <select name="attr_action_target">
                                     <option value="None" selected="selected">None</option>
-                                    <option value="Evasion">Evasion</option>
+                                    <option value="Guard">Guard</option>
                                     <option value="Toughness">Toughness</option>
                                     <option value="Resolve">Resolve</option>
                                 </select>
                             </div>
                             <input type="hidden" name="attr_dice_roll" value=0 />
-                            <div class="column width75 inlineBlock">Increase/Decrease dice size:</div>
+                            <div class="column width75 inlineBlock">Attribute Dice Bonus/Penalty:</div>
                             <div class="column width25 inlineBlock inputNumber30"><input type="number" name="attr_dice_modifier" value=0 /></div>
                             <div class="column width55 inlineBlock">d20 for this action is:</div>
                             <input type="hidden" name="attr_dice_d20" value="1d20!!" />

--- a/Open Legend Basic by Great Moustache/ReadMe.md
+++ b/Open Legend Basic by Great Moustache/ReadMe.md
@@ -5,6 +5,18 @@
 
 ### Changelog
 
+### 1.7.7 on 2017 January 27th
+* Added Attribute Substitution for all Attributes
+	- Fixed drop downs to have ALL attributes except for the current attribute being looked at
+* Updated all function calls to account for 1.7.6
+	- Including calculations to display prorperly if attribute subsitution was being used
+
+### 1.7.6 on 2017 January 24th
+* Added new universal function for determining attribute substitution values
+	- Reusable code so less lines of code
+* Updated drop down menus to reflect change of Evasion > Guard
+* Renames lines "Increase/Decrease Dice Size" to be "Attribute Dice Bonus/Penalty"
+
 ### 1.7.5 on 2017 January 4th
 * Updated for new calculation of evasion, and evasion's name changed to Guard
 	- Guard = 10 + Agility + Might + Armor + Other


### PR DESCRIPTION
### 1.7.7 on 2017 January 27th
* Added Attribute Substitution for all Attributes
- Fixed drop downs to have ALL attributes except for the current
attribute being looked at
* Updated all function calls to account for 1.7.6
- Including calculations to display prorperly if attribute subsitution
was being used

### 1.7.6 on 2017 January 24th
* Added new universal function for determining attribute substitution
values
- Reusable code so less lines of code
* Updated drop down menus to reflect change of Evasion > Guard
* Renames lines "Increase/Decrease Dice Size" to be "Attribute Dice
Bonus/Penalty"